### PR TITLE
Implement standard traits for pointers and bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
+
+For all future releases, please manage versions as follows:
+
+1. Briefly summarize notable changes in this file (`CHANGELOG.md`). If the release includes *breaking changes*, provide clear migration instructions.
+2. Publish the new version on crates.io and create a new release on [GitHub Releases](https://github.com/kaist-cp/circ/releases).
+
+---
+
+## Version 0.2.0 - 2024-10-03
+
+### Features
+
+* Added implementation of standard traits for pointers. ([#3](https://github.com/kaist-cp/circ/pull/3))
+
+### Bug Fixes
+
+* `PartialEq` for `Rc` and `Snapshot` now compares the objects they point to, rather than the pointers themselves. ([#3](https://github.com/kaist-cp/circ/pull/3)) (See compatibility note below.)
+
+### Compatibility Notes
+
+* `Rc::eq` and `Snapshot::eq` now compare the objects they point to instead of their pointer values. This change aligns with the behavior of `PartialEq` for other smart pointer types (e.g., `std::rc::Rc`), where equality is based on the objects being pointed to. The original pointer-based comparison is still available via the `ptr_eq` method.
+  * **Migration**: To compare pointer values, use the `ptr_eq` method. 
+
+## Version 0.1.0 - 2024-06-12
+
+* Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For all future releases, please manage versions as follows:
 
 ---
 
+## Unreleased
+<!-- TODO -->
+
 ## Version 0.2.0 - 2024-10-03
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circ"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Efficient referenced counted pointers for non-blocking concurrency"

--- a/src/ebr_impl/pointers.rs
+++ b/src/ebr_impl/pointers.rs
@@ -131,8 +131,13 @@ impl<T> Tagged<T> {
         }
     }
 
+    /// Returns `true` if the two pointer values, including the tag values set by `with_tag`,
+    /// are identical.
     pub fn ptr_eq(self, other: Self) -> bool {
-        // Ignore the epoch tags, and compare between pointer values.
+        // Instead of using a direct equality comparison (`==`), we use `ptr_eq`, which ignores
+        // the epoch tag in the high bits. This is because the epoch tags hold no significance
+        // for clients; they are only used internally by the CIRC engine to track the last
+        // accessed epoch for the pointer.
         self.with_high_tag(0).ptr == other.with_high_tag(0).ptr
     }
 }
@@ -248,7 +253,13 @@ impl<'g, T> From<Tagged<T>> for RawShared<'g, T> {
 }
 
 impl<'g, T> PartialEq for RawShared<'g, T> {
+    /// Returns `true` if the two pointer values, including the tag values set by `with_tag`,
+    /// are identical.
     fn eq(&self, other: &Self) -> bool {
+        // Instead of using a direct equality comparison (`==`), we use `ptr_eq`, which ignores
+        // the epoch tag in the high bits. This is because the epoch tags hold no significance
+        // for clients; they are only used internally by the CIRC engine to track the last
+        // accessed epoch for the pointer.
         self.inner.ptr_eq(other.inner)
     }
 }

--- a/src/ebr_impl/pointers.rs
+++ b/src/ebr_impl/pointers.rs
@@ -252,18 +252,6 @@ impl<'g, T> From<Tagged<T>> for RawShared<'g, T> {
     }
 }
 
-impl<'g, T> PartialEq for RawShared<'g, T> {
-    /// Returns `true` if the two pointer values, including the tag values set by `with_tag`,
-    /// are identical.
-    fn eq(&self, other: &Self) -> bool {
-        // Instead of using a direct equality comparison (`==`), we use `ptr_eq`, which ignores
-        // the epoch tag in the high bits. This is because the epoch tags hold no significance
-        // for clients; they are only used internally by the CIRC engine to track the last
-        // accessed epoch for the pointer.
-        self.inner.ptr_eq(other.inner)
-    }
-}
-
 impl<'g, T> RawShared<'g, T> {
     pub fn null() -> Self {
         Self {
@@ -309,5 +297,15 @@ impl<'g, T> RawShared<'g, T> {
     #[cfg(test)]
     pub fn is_null(self) -> bool {
         self.inner.is_null()
+    }
+
+    /// Returns `true` if the two pointer values, including the tag values set by `with_tag`,
+    /// are identical.
+    pub fn ptr_eq(&self, other: Self) -> bool {
+        // Instead of using a direct equality comparison (`==`), we use `ptr_eq`, which ignores
+        // the epoch tag in the high bits. This is because the epoch tags hold no significance
+        // for clients; they are only used internally by the CIRC engine to track the last
+        // accessed epoch for the pointer.
+        self.inner.ptr_eq(other.inner)
     }
 }

--- a/src/ebr_impl/sync/queue.rs
+++ b/src/ebr_impl/sync/queue.rs
@@ -122,7 +122,7 @@ impl<T> Queue<T> {
                     .map(|_| {
                         let tail = self.tail.load(Relaxed, guard);
                         // Advance the tail so that we don't retire a pointer to a reachable node.
-                        if head == tail {
+                        if head.ptr_eq(tail) {
                             let _ = self
                                 .tail
                                 .compare_exchange(tail, next, Release, Relaxed, guard);
@@ -154,7 +154,7 @@ impl<T> Queue<T> {
                     .map(|_| {
                         let tail = self.tail.load(Relaxed, guard);
                         // Advance the tail so that we don't retire a pointer to a reachable node.
-                        if head == tail {
+                        if head.ptr_eq(tail) {
                             let _ = self
                                 .tail
                                 .compare_exchange(tail, next, Release, Relaxed, guard);

--- a/src/strong.rs
+++ b/src/strong.rs
@@ -665,11 +665,7 @@ impl<T: RcObject> Drop for Rc<T> {
 impl<T: RcObject + PartialEq> PartialEq for Rc<T> {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
-        match (self.as_ref(), other.as_ref()) {
-            (None, None) => true,
-            (Some(x), Some(y)) => x.eq(y),
-            (_, _) => false,
-        }
+        self.as_ref() == other.as_ref()
     }
 }
 
@@ -895,11 +891,7 @@ impl<'g, T: RcObject> Default for Snapshot<'g, T> {
 impl<'g, T: RcObject + PartialEq> PartialEq for Snapshot<'g, T> {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
-        match (self.as_ref(), other.as_ref()) {
-            (None, None) => true,
-            (Some(x), Some(y)) => x.eq(y),
-            (_, _) => false,
-        }
+        self.as_ref() == other.as_ref()
     }
 }
 

--- a/src/strong.rs
+++ b/src/strong.rs
@@ -667,8 +667,8 @@ impl<T: RcObject + PartialEq> PartialEq for Rc<T> {
     fn eq(&self, other: &Self) -> bool {
         match (self.as_ref(), other.as_ref()) {
             (None, None) => true,
-            (None, Some(_)) | (Some(_), None) => false,
             (Some(x), Some(y)) => x.eq(y),
+            (_, _) => false,
         }
     }
 }
@@ -897,8 +897,8 @@ impl<'g, T: RcObject + PartialEq> PartialEq for Snapshot<'g, T> {
     fn eq(&self, other: &Self) -> bool {
         match (self.as_ref(), other.as_ref()) {
             (None, None) => true,
-            (None, Some(_)) | (Some(_), None) => false,
             (Some(x), Some(y)) => x.eq(y),
+            (_, _) => false,
         }
     }
 }

--- a/src/strong.rs
+++ b/src/strong.rs
@@ -610,10 +610,14 @@ impl<T: RcObject> Rc<T> {
         }
     }
 
-    /// Returns true if the two [`Rc`]s point to the same allocation in a vein similar to
-    /// [`std::ptr::eq`].
+    /// Returns `true` if the two pointer values, including the tag values set by `with_tag`,
+    /// are identical.
     #[inline]
     pub fn ptr_eq(&self, other: &Self) -> bool {
+        // Instead of using a direct equality comparison (`==`), we use `ptr_eq`, which ignores
+        // the epoch tag in the high bits. This is because the epoch tags hold no significance
+        // for clients; they are only used internally by the CIRC engine to track the last
+        // accessed epoch for the pointer.
         self.ptr.ptr_eq(other.ptr)
     }
 }
@@ -850,10 +854,14 @@ impl<'g, T: RcObject> Snapshot<'g, T> {
         }
     }
 
-    /// Returns true if the two [`Rc`]s point to the same allocation in a vein similar to
-    /// [`std::ptr::eq`].
+    /// Returns `true` if the two pointer values, including the tag values set by `with_tag`,
+    /// are identical.
     #[inline]
     pub fn ptr_eq(self, other: Self) -> bool {
+        // Instead of using a direct equality comparison (`==`), we use `ptr_eq`, which ignores
+        // the epoch tag in the high bits. This is because the epoch tags hold no significance
+        // for clients; they are only used internally by the CIRC engine to track the last
+        // accessed epoch for the pointer.
         self.ptr.ptr_eq(other.ptr)
     }
 }

--- a/src/strong.rs
+++ b/src/strong.rs
@@ -1,5 +1,7 @@
 use std::{
     array,
+    fmt::{Debug, Formatter, Pointer},
+    hash::{Hash, Hasher},
     marker::PhantomData,
     mem::{forget, size_of},
     sync::atomic::{AtomicUsize, Ordering},
@@ -196,24 +198,24 @@ impl<T: RcObject> AtomicRc<T> {
         failure: Ordering,
         guard: &'g Guard,
     ) -> Result<Rc<T>, CompareExchangeError<Rc<T>, Snapshot<'g, T>>> {
-        let mut expected_ptr = expected.ptr;
-        let desired_ptr = desired.ptr.with_timestamp();
+        let mut expected_raw = expected.ptr;
+        let desired_raw = desired.ptr.with_timestamp();
         loop {
             match self
                 .link
-                .compare_exchange(expected_ptr, desired_ptr, success, failure)
+                .compare_exchange(expected_raw, desired_raw, success, failure)
             {
                 Ok(_) => {
                     // Skip decrementing a strong count of the inserted pointer.
                     forget(desired);
-                    let rc = Rc::from_raw(expected_ptr);
+                    let rc = Rc::from_raw(expected_raw);
                     return Ok(rc);
                 }
-                Err(current) => {
-                    if current.with_high_tag(0) == expected_ptr.with_high_tag(0) {
-                        expected_ptr = current;
+                Err(current_raw) => {
+                    if current_raw.ptr_eq(expected_raw) {
+                        expected_raw = current_raw;
                     } else {
-                        let current = Snapshot::from_raw(current, guard);
+                        let current = Snapshot::from_raw(current_raw, guard);
                         return Err(CompareExchangeError { desired, current });
                     }
                 }
@@ -248,24 +250,24 @@ impl<T: RcObject> AtomicRc<T> {
         failure: Ordering,
         guard: &'g Guard,
     ) -> Result<Rc<T>, CompareExchangeError<Rc<T>, Snapshot<'g, T>>> {
-        let mut expected_ptr = expected.ptr;
-        let desired_ptr = desired.ptr.with_timestamp();
+        let mut expected_raw = expected.ptr;
+        let desired_raw = desired.ptr.with_timestamp();
         loop {
             match self
                 .link
-                .compare_exchange_weak(expected_ptr, desired_ptr, success, failure)
+                .compare_exchange_weak(expected_raw, desired_raw, success, failure)
             {
                 Ok(_) => {
                     // Skip decrementing a strong count of the inserted pointer.
                     forget(desired);
-                    let rc = Rc::from_raw(expected_ptr);
+                    let rc = Rc::from_raw(expected_raw);
                     return Ok(rc);
                 }
-                Err(current) => {
-                    if current.with_high_tag(0) == expected_ptr.with_high_tag(0) {
-                        expected_ptr = current;
+                Err(current_raw) => {
+                    if current_raw.ptr_eq(expected_raw) {
+                        expected_raw = current_raw;
                     } else {
-                        let current = Snapshot::from_raw(current, guard);
+                        let current = Snapshot::from_raw(current_raw, guard);
                         return Err(CompareExchangeError { desired, current });
                     }
                 }
@@ -312,14 +314,14 @@ impl<T: RcObject> AtomicRc<T> {
                 .link
                 .compare_exchange(expected_raw, desired_raw, success, failure)
             {
-                Ok(current) => return Ok(Snapshot::from_raw(current, guard)),
-                Err(current) => {
-                    if current.with_high_tag(0) == expected_raw.with_high_tag(0) {
-                        expected_raw = current;
+                Ok(current_raw) => return Ok(Snapshot::from_raw(current_raw, guard)),
+                Err(current_raw) => {
+                    if current_raw.ptr_eq(expected_raw) {
+                        expected_raw = current_raw;
                     } else {
                         return Err(CompareExchangeError {
                             desired: Snapshot::from_raw(desired_raw, guard),
-                            current: Snapshot::from_raw(current, guard),
+                            current: Snapshot::from_raw(current_raw, guard),
                         });
                     }
                 }
@@ -378,6 +380,25 @@ impl<T: RcObject> From<Rc<T>> for AtomicRc<T> {
             link: Atomic::new(ptr),
             _marker: PhantomData,
         }
+    }
+}
+
+impl<T: RcObject> From<&Rc<T>> for AtomicRc<T> {
+    #[inline]
+    fn from(value: &Rc<T>) -> Self {
+        Self::from(value.clone())
+    }
+}
+
+impl<T: RcObject> Debug for AtomicRc<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.link.load(Ordering::Relaxed), f)
+    }
+}
+
+impl<T: RcObject> Pointer for AtomicRc<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Pointer::fmt(&self.link.load(Ordering::Relaxed), f)
     }
 }
 
@@ -588,6 +609,35 @@ impl<T: RcObject> Rc<T> {
             Some(unsafe { self.deref_mut() })
         }
     }
+
+    /// Returns true if the two [`Rc`]s point to the same allocation in a vein similar to
+    /// [`std::ptr::eq`].
+    #[inline]
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        self.ptr.ptr_eq(other.ptr)
+    }
+}
+
+impl<'g, T: RcObject> From<Snapshot<'g, T>> for Rc<T> {
+    fn from(value: Snapshot<'g, T>) -> Self {
+        value.counted()
+    }
+}
+
+impl<T: RcObject + Debug> Debug for Rc<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(cnt) = self.as_ref() {
+            f.debug_tuple("RcObject").field(cnt).finish()
+        } else {
+            f.write_str("Null")
+        }
+    }
+}
+
+impl<T: RcObject> Pointer for Rc<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Pointer::fmt(&self.ptr, f)
+    }
 }
 
 impl<T: RcObject> Default for Rc<T> {
@@ -608,10 +658,34 @@ impl<T: RcObject> Drop for Rc<T> {
     }
 }
 
-impl<T: RcObject> PartialEq for Rc<T> {
+impl<T: RcObject + PartialEq> PartialEq for Rc<T> {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
-        self.ptr == other.ptr
+        match (self.as_ref(), other.as_ref()) {
+            (None, None) => true,
+            (None, Some(_)) | (Some(_), None) => false,
+            (Some(x), Some(y)) => x.eq(y),
+        }
+    }
+}
+
+impl<T: RcObject + Eq> Eq for Rc<T> {}
+
+impl<T: RcObject + Hash> Hash for Rc<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl<T: RcObject + PartialOrd> PartialOrd for Rc<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_ref().partial_cmp(&other.as_ref())
+    }
+}
+
+impl<T: RcObject + Ord> Ord for Rc<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_ref().cmp(&other.as_ref())
     }
 }
 
@@ -775,6 +849,13 @@ impl<'g, T: RcObject> Snapshot<'g, T> {
             Some(unsafe { self.deref_mut() })
         }
     }
+
+    /// Returns true if the two [`Rc`]s point to the same allocation in a vein similar to
+    /// [`std::ptr::eq`].
+    #[inline]
+    pub fn ptr_eq(self, other: Self) -> bool {
+        self.ptr.ptr_eq(other.ptr)
+    }
 }
 
 impl<'g, T> Snapshot<'g, T> {
@@ -803,9 +884,49 @@ impl<'g, T: RcObject> Default for Snapshot<'g, T> {
     }
 }
 
-impl<'g, T> PartialEq for Snapshot<'g, T> {
+impl<'g, T: RcObject + PartialEq> PartialEq for Snapshot<'g, T> {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
-        self.ptr.eq(&other.ptr)
+        match (self.as_ref(), other.as_ref()) {
+            (None, None) => true,
+            (None, Some(_)) | (Some(_), None) => false,
+            (Some(x), Some(y)) => x.eq(y),
+        }
+    }
+}
+
+impl<'g, T: RcObject + Eq> Eq for Snapshot<'g, T> {}
+
+impl<'g, T: RcObject + Hash> Hash for Snapshot<'g, T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_ref().hash(state);
+    }
+}
+
+impl<'g, T: RcObject + PartialOrd> PartialOrd for Snapshot<'g, T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_ref().partial_cmp(&other.as_ref())
+    }
+}
+
+impl<'g, T: RcObject + Ord> Ord for Snapshot<'g, T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_ref().cmp(&other.as_ref())
+    }
+}
+
+impl<'g, T: RcObject + Debug> Debug for Snapshot<'g, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Some(cnt) = self.as_ref() {
+            f.debug_tuple("RcObject").field(cnt).finish()
+        } else {
+            f.write_str("Null")
+        }
+    }
+}
+
+impl<'g, T: RcObject> Pointer for Snapshot<'g, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Pointer::fmt(&self.ptr, f)
     }
 }

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -364,8 +364,14 @@ impl<T> Weak<T> {
         }
     }
 
+    /// Returns `true` if the two pointer values, including the tag values set by `with_tag`,
+    /// are identical.
     #[inline]
     pub fn ptr_eq(&self, other: &Self) -> bool {
+        // Instead of using a direct equality comparison (`==`), we use `ptr_eq`, which ignores
+        // the epoch tag in the high bits. This is because the epoch tags hold no significance
+        // for clients; they are only used internally by the CIRC engine to track the last
+        // accessed epoch for the pointer.
         self.ptr.ptr_eq(other.ptr)
     }
 }
@@ -501,8 +507,14 @@ impl<'g, T> WeakSnapshot<'g, T> {
         }
     }
 
+    /// Returns `true` if the two pointer values, including the tag values set by `with_tag`,
+    /// are identical.
     #[inline]
     pub fn ptr_eq(self, other: Self) -> bool {
+        // Instead of using a direct equality comparison (`==`), we use `ptr_eq`, which ignores
+        // the epoch tag in the high bits. This is because the epoch tags hold no significance
+        // for clients; they are only used internally by the CIRC engine to track the last
+        // accessed epoch for the pointer.
         self.ptr.ptr_eq(other.ptr)
     }
 }

--- a/tests/harris_list.rs
+++ b/tests/harris_list.rs
@@ -105,7 +105,7 @@ impl<'g, K: Ord, V> Cursor<'g, K, V> {
         };
 
         // If prev and curr WERE adjacent, no need to clean up
-        if prev_next == self.curr {
+        if prev_next.ptr_eq(self.curr) {
             return Ok(found);
         }
 


### PR DESCRIPTION
* Resolves #1 
  * For all pointer types, implemented `Debug` and `Pointer`.
  * For dereferenceable types (i.e., `Rc` and `Snapshot`), implemented `PartialOrd`, `Ord`, `PartialEq`, `Eq`, and `Hash`.
  * Implemented `From` by referring to [the type relation graph](https://github.com/kaist-cp/circ?tab=readme-ov-file#type-relation). 
* Resolves #2 
  * Now `Rc::eq` and `Snapshot::eq` compare by objects they are pointing to. To compare by pointer values, use the `ptr_eq` method instead.
  * This patch is a breaking-change because it changes the behavior of a pre-existing API. Therefore, we need to increment the non-zero left-most version number (i.e., `0.1.0` -> `0.2.0`).