### PR TITLE
.github: Update GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        submodules: recursive
-
-    - name: Install Rust nightly toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
         components: rustfmt, clippy
-
+    - uses: Swatinem/rust-cache@v2
     - name: Install cargo-audit
       run: cargo install cargo-audit
 


### PR DESCRIPTION
- Use actions/checkout@v4 instead of v3
- actions-rs/toolchain has been obsoleted for 4 years. Use dtolnay/rust-toolchain instead
- Use stable toolchain instead of nightly
- Cache builds to be green